### PR TITLE
Fix missing boost format headers

### DIFF
--- a/lib/add_usrp_tags_impl.cc
+++ b/lib/add_usrp_tags_impl.cc
@@ -63,7 +63,7 @@ template <class T>
 void add_usrp_tags_impl<T>::update_tags(pmt::pmt_t update)
 {
     if (!pmt::is_dict(update)) {
-        GR_LOG_NOTICE(this->d_logger, "received unexpected PMT (non-dict)");
+        this->d_logger->notice("received unexpected PMT (non-dict)");
         return;
     }
 
@@ -80,7 +80,7 @@ void add_usrp_tags_impl<T>::update_tags(pmt::pmt_t update)
     d_pmt_dict = pmt::dict_add(d_pmt_dict, PMTCONSTSTR__rx_rate(), d_rate_pmt);
     d_pmt_dict = pmt::dict_add(d_pmt_dict, PMTCONSTSTR__rx_freq(), d_freq_pmt);
     d_pmt_dict = pmt::dict_add(d_pmt_dict, PMTCONSTSTR__rx_time(), d_time_pmt);
-    GR_LOG_DEBUG(this->d_logger, "Updating tags");
+    this->d_logger->debug("Updating tags");
 }
 
 template <class T>

--- a/lib/interrupt_emitter_impl.cc
+++ b/lib/interrupt_emitter_impl.cc
@@ -80,7 +80,7 @@ pmt::pmt_t interrupt_emitter_impl<T>::samples_to_tpmt(uint64_t trigger_sample)
     if (time < 0) {
         // this is an unlikely edge case where sample/WCT has experienced sudden slew,
         // catch it set the time to the minimum representable value, zero
-        GR_LOG_DEBUG(this->d_logger,
+        this->d_logger->debug(
             "Late sampled-based interrupt request received...setting time to minimum representable value");
         time = 0;
     }
@@ -99,7 +99,7 @@ uint64_t interrupt_emitter_impl<T>::time_to_samples(double time)
 {
     uint64_t sample;
     if (time < d_start_time) {
-        GR_LOG_DEBUG(this->d_logger, 
+        this->d_logger->debug(
             "Sample time precedes last sample processed...setting sample index to last sample processed");
         sample = d_start_sample;
     } else {
@@ -163,8 +163,7 @@ void interrupt_emitter_impl<T>::handle_set_time(pmt::pmt_t time_pmt)
 
     if (wait_time < 0) {
         if (d_drop_late) {
-            GR_LOG_DEBUG(this->d_logger,
-                         boost::format("Dropping late interrupt request: %0.2f") %
+            this->d_logger->debug("Dropping late interrupt request: {:e}",
                              wait_time);
         } else {
             // Interrupt right now

--- a/lib/interrupt_emitter_impl.cc
+++ b/lib/interrupt_emitter_impl.cc
@@ -15,6 +15,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/timing_utils/constants.h>
 #include <cmath>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace timing_utils {

--- a/lib/system_time_diff_impl.cc
+++ b/lib/system_time_diff_impl.cc
@@ -13,7 +13,7 @@
 
 #include "system_time_diff_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace timing_utils {
 

--- a/lib/system_time_tagger_impl.cc
+++ b/lib/system_time_tagger_impl.cc
@@ -78,8 +78,7 @@ int system_time_tagger_impl<T>::work(int noutput_items,
                 d_next_tag_offset += d_interval;
             } else {
                 // we should not have gotten into this state...
-                GR_LOG_WARN(
-                    this->d_logger,
+                this->d_logger->warn(
                     "unexpected state: attempted to tag item in previous work call!");
                 // reset the next tag offset to the first item in the next input buffer;
                 d_next_tag_offset = d_total_nitems_read;

--- a/lib/tag_uhd_offset_impl.cc
+++ b/lib/tag_uhd_offset_impl.cc
@@ -13,7 +13,7 @@
 
 #include "tag_uhd_offset_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace timing_utils {
 

--- a/lib/tag_uhd_offset_impl.cc
+++ b/lib/tag_uhd_offset_impl.cc
@@ -41,7 +41,7 @@ tag_uhd_offset_impl<T>::tag_uhd_offset_impl(float rate, uint32_t tag_interval)
       d_time_tag(pmt::PMT_NIL)
 {
     set_interval(tag_interval);
-    GR_LOG_INFO(this->d_logger, "setting up time tagger");
+    this->d_logger->info("setting up time tagger");
 
     this->message_port_register_out(PMTCONSTSTR__time());
 }
@@ -80,9 +80,8 @@ void tag_uhd_offset_impl<T>::update_time_tag(uint64_t offset)
 {
     double delta = ((offset - d_time_tag_offset) / d_rate);
     if (delta < 0) {
-        GR_LOG_ERROR(this->d_logger,
-                     boost::format("can't go back in time...updating time tag failed "
-                                   "(requested delta = %fs)") %
+        this->d_logger->error("can't go back in time...updating time tag failed "
+                                   "(requested delta = {:e}s)",
                          delta);
         return;
     }
@@ -148,8 +147,7 @@ int tag_uhd_offset_impl<T>::work(int noutput_items,
                 // d_next_tag_offset);
             } else {
                 // we should not have gotten into this state...
-                GR_LOG_WARN(
-                    this->d_logger,
+                this->d_logger->warn(
                     "unexpected state: attempted to tag item in previous work call!");
                 // reset the next tag offset to the first item in the next input buffer;
                 d_next_tag_offset = d_total_nitems_read;

--- a/lib/thresh_trigger_f_impl.cc
+++ b/lib/thresh_trigger_f_impl.cc
@@ -57,7 +57,7 @@ void thresh_trigger_f_impl::disarm(pmt::pmt_t msg)
 {
     // effectively disables the trigger
     d_length = d_length_thresh + 1;
-    GR_LOG_INFO(d_logger, "disarmed!");
+    d_logger->info("disarmed!");
 }
 
 

--- a/lib/time_delta_impl.cc
+++ b/lib/time_delta_impl.cc
@@ -13,7 +13,7 @@
 
 #include "time_delta_impl.h"
 #include <gnuradio/io_signature.h>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace timing_utils {
 

--- a/lib/time_delta_impl.cc
+++ b/lib/time_delta_impl.cc
@@ -53,10 +53,8 @@ bool time_delta_impl::stop()
     double mean = d_sum_x / (double)d_n;
     double var = (d_sum_x2 - (d_sum_x * d_sum_x) / (double)d_n) / (double)d_n;
 
-    GR_LOG_INFO(
-        d_logger,
-        boost::format("WALL_CLOCK_TIME_DEBUG (%s): Mean = %0.6f ms, Var = %0.6f ms") %
-            d_name % mean % var);
+    d_logger->info("WALL_CLOCK_TIME_DEBUG ({}): Mean = {:e} ms, Var = {:e} ms",
+            d_name, mean, var);
     return true;
 }
 
@@ -65,7 +63,7 @@ void time_delta_impl::handle_pdu(pmt::pmt_t pdu)
 
     // make sure PDU data is formed properly
     if (!(pmt::is_pair(pdu))) {
-        GR_LOG_DEBUG(d_logger, "received unexpected PMT (non-pair)");
+        d_logger->debug("received unexpected PMT (non-pair)");
         message_port_pub(PMTCONSTSTR__pdu_out(), pdu);
         return;
     }
@@ -75,22 +73,19 @@ void time_delta_impl::handle_pdu(pmt::pmt_t pdu)
     pmt::pmt_t meta = pmt::car(pdu);
 
     if (!pmt::is_dict(meta)) {
-        GR_LOG_DEBUG(d_logger, "received malformed PDU");
+        d_logger->debug("received malformed PDU");
         message_port_pub(PMTCONSTSTR__pdu_out(), pdu);
         return;
     }
 
     pmt::pmt_t wct_pmt = pmt::dict_ref(meta, d_time_key, pmt::PMT_NIL);
     if (!pmt::is_real(wct_pmt)) {
-        GR_LOG_DEBUG(d_logger,
-                     boost::format("PDU received with no wall clock time at %f") % t_now);
+        d_logger->debug("PDU received with no wall clock time at {:e}",t_now);
     } else {
         double pdu_time = pmt::to_double(wct_pmt);
         double time_delta = (t_now - pdu_time) * 1000.0;
-        GR_LOG_DEBUG(
-            d_logger,
-            boost::format("%s PDU received at %f with time delta %f milliseconds") %
-                d_name % t_now % time_delta);
+        d_logger->debug("{} PDU received at {:e} with time delta {:e} milliseconds",
+                d_name, t_now, time_delta);
 
         // add to metadata
         meta = pmt::dict_add(meta, d_delta_key, pmt::from_double(time_delta));

--- a/lib/timed_freq_xlating_fir_impl.cc
+++ b/lib/timed_freq_xlating_fir_impl.cc
@@ -282,11 +282,9 @@ int timed_freq_xlating_fir_impl<I, O, T>::work(int noutput_items,
                     double new_phase = pmt::to_double(pmt::cdr(tags[0].value));
                     handle_set_center_freq(pmt::dict_add(
                         pmt::make_dict(), PMTCONSTSTR__freq(), tags[0].value));
-                    GR_LOG_INFO(
-                        this->d_logger,
-                        boost::format("Synchronously setting freq xlator to %f Hz with a "
-                                      "phase of %f radians at sample %d") %
-                            new_freq % new_phase % tags[0].offset);
+                        this->d_logger->info("Synchronously setting freq xlator to {:e} Hz with a "
+                                      "phase of {:e} radians at sample {}",
+                            new_freq, new_phase, tags[0].offset);
                     d_tag_freq_applied = true;
                 } else if (pmt::is_real(tags[0].value)) {
                     double new_freq = pmt::to_double(tags[0].value);
@@ -294,15 +292,13 @@ int timed_freq_xlating_fir_impl<I, O, T>::work(int noutput_items,
                         // inform the block to retune the next time it is run
                         handle_set_center_freq(pmt::dict_add(
                             pmt::make_dict(), PMTCONSTSTR__freq(), tags[0].value));
-                        GR_LOG_INFO(
-                            this->d_logger,
-                            boost::format(
-                                "Synchronously setting freq xlator to %f at sample %d") %
-                                new_freq % tags[0].offset);
+                            this->d_logger->info(
+                                "Synchronously setting freq xlator to {:e} at sample {}",
+                                new_freq, tags[0].offset);
                     }
                     d_tag_freq_applied = true;
                 } else {
-                    GR_LOG_ERROR(this->d_logger, "Invalid frequency tag type");
+                    this->d_logger->error("Invalid frequency tag type");
                 }
             } else {
                 // tag frequency was applied on previous iteration so mark unapplied

--- a/lib/timed_freq_xlating_fir_impl.cc
+++ b/lib/timed_freq_xlating_fir_impl.cc
@@ -15,6 +15,7 @@
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
 #include <stdexcept>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace timing_utils {

--- a/lib/timed_tag_retuner_impl.cc
+++ b/lib/timed_tag_retuner_impl.cc
@@ -68,7 +68,7 @@ void timed_tag_retuner_impl::command_handler(pmt::pmt_t msg)
     gr::thread::scoped_lock l(this->d_setlock);
 
     if (!pmt::is_dict(msg)) {
-        GR_LOG_ERROR(d_logger, "Retune commands must be dictioanries");
+        d_logger->error("Retune commands must be dictioanries");
         return;
     }
 
@@ -76,7 +76,7 @@ void timed_tag_retuner_impl::command_handler(pmt::pmt_t msg)
     try {
         lo_offset = pmt::dict_ref(msg, d_dict_key, pmt::PMT_NIL);
     } catch (...) {
-        GR_LOG_ERROR(d_logger, "Unable to read dictionary keys");
+        d_logger->error("Unable to read dictionary keys");
         return;
     }
     if (!pmt::equal(lo_offset, pmt::PMT_NIL)) {
@@ -84,7 +84,7 @@ void timed_tag_retuner_impl::command_handler(pmt::pmt_t msg)
         try {
             offset = pmt::to_double(lo_offset);
         } catch (...) {
-            GR_LOG_ERROR(d_logger, "Tune offset is wrong type.  Should be double");
+            d_logger->error("Tune offset is wrong type.  Should be double");
             return;
         }
 
@@ -105,7 +105,7 @@ void timed_tag_retuner_impl::command_handler(pmt::pmt_t msg)
                 tag_now = false;
             }
         } catch (...) {
-            GR_LOG_ERROR(d_logger, "Unable to determine retune time.  Tagging now");
+            d_logger->error("Unable to determine retune time.  Tagging now");
         }
 
         // only push command onto stack if space allows
@@ -142,7 +142,7 @@ int timed_tag_retuner_impl::work(int noutput_items,
             double frac = pmt::to_double(pmt::tuple_ref(tags[end].value, 1));
             d_ref_time.set(secs, frac, offset);
         } catch (...) {
-            GR_LOG_ERROR(d_logger, "Invalid tag value");
+            d_logger->error("Invalid tag value");
         }
     }
 

--- a/lib/wall_clock_time_impl.cc
+++ b/lib/wall_clock_time_impl.cc
@@ -49,7 +49,7 @@ void wall_clock_time_impl::handle_pdu(pmt::pmt_t pdu)
 {
     // make sure PDU data is formed properly
     if (!(pmt::is_pair(pdu))) {
-        GR_LOG_WARN(d_logger, "received unexpected PMT (non-pair)");
+        d_logger->warn("received unexpected PMT (non-pair)");
         return;
     }
 


### PR DESCRIPTION
This adds missing boost format headers which will cause errors on compiling with gnuradio 3.10/ubuntu 22.04