### PR TITLE
Remove gr sandia utils dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,6 @@ find_package(Doxygen)
 # Dependencies
 ########################################################################
 find_package(gnuradio-pdu_utils "3.10.0" REQUIRED)
-find_package(gnuradio-sandia_utils "3.10" REQUIRED)
 
 ########################################################################
 # Setup doxygen option


### PR DESCRIPTION
The gr-sandia_utils module is no longer required to build this module, so this PR removes that dependency.